### PR TITLE
Sidekiq6 に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,20 @@ A gem that formats [Sidekiq](https://github.com/mperham/sidekiq) logs into JSON 
   "@timestamp": "2020-09-01T18:41:42Z",
   "@fields": {
     "pid": 1234,
-    "tid": "TID-1o3t9o",
-    "context": "ExampleWorker JID-deda0f0c174afad251121282",
-    "program_name":null,
-    "worker":"ExampleWorker",
-  },
+    "tid": "TID-1o3t9o", 
+    "context": {
+      "class": "ExampleWorker",
+      "jid": "7094855b3de6a4507c9825ec",
+      "elapsed": "51.579"
+    },
+    "program_name": null,
+    "worker": "ExampleWorker"
+  }, 
   "@type": "sidekiq",
   "@status": "done",
-  "@severity": "INFO",
+  "@severity": "INFO", 
   "@run_time": 51.579,
-  "@message": "done: 37.298 sec"
+  "@message": "done"
 }
 ```
 

--- a/sidekiq-log_json_formatter.gemspec
+++ b/sidekiq-log_json_formatter.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'sidekiq-log_json_formatter'
-  spec.version       = '0.0.1'
+  spec.version       = '2.0.0'
   spec.authors       = ['hekki']
   spec.email         = ['contact@hekki.info']
 
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rspec'
 
-  spec.add_dependency 'sidekiq', '~> 5'
+  spec.add_dependency 'sidekiq', '~> 6'
 end

--- a/spec/sidekiq/log_json_formatter_spec.rb
+++ b/spec/sidekiq/log_json_formatter_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe 'Sidekiq::LogJsonFormatter' do
     end
 
     context 'debug severity' do
-      before do
-        allow_any_instance_of(Sidekiq::LogJsonFormatter).to receive(:context).and_return('')
-      end
-
       let(:severity) { 'DEBUG' }
       let(:message) { 'debug message' }
       let(:worker) { nil }
@@ -38,7 +34,7 @@ RSpec.describe 'Sidekiq::LogJsonFormatter' do
 
     context 'INFO severity' do
       before do
-        allow_any_instance_of(Sidekiq::LogJsonFormatter).to receive(:context).and_return("#{worker} #{jid}")
+        allow_any_instance_of(Sidekiq::LogJsonFormatter).to receive(:ctx).and_return(ctx)
       end
 
       let(:severity) { 'INFO' }
@@ -46,6 +42,7 @@ RSpec.describe 'Sidekiq::LogJsonFormatter' do
       let(:jid) { 'JID-xxxxxxxxxxxxxxxxxxxxxx' }
 
       context 'status: start' do
+        let(:ctx) { { 'class': 'TestWorker', 'jid': 'xxxxxxxxxxxxxxxxxxxxxx' } }
         let(:message) { 'start' }
         let(:status) { 'start' }
         let(:run_time) { nil }
@@ -54,7 +51,8 @@ RSpec.describe 'Sidekiq::LogJsonFormatter' do
       end
 
       context 'status: done' do
-        let(:message) { 'done: 0.015 sec' }
+        let(:ctx) { { 'class': 'TestWorker', 'jid': 'xxxxxxxxxxxxxxxxxxxxxx', 'elapsed': '0.015' } }
+        let(:message) { 'done' }
         let(:status) { 'done' }
         let(:run_time) { 0.015 }
 
@@ -62,7 +60,8 @@ RSpec.describe 'Sidekiq::LogJsonFormatter' do
       end
 
       context 'status: fail' do
-        let(:message) { 'fail: 0.123 sec' }
+        let(:ctx) { { 'class': 'TestWorker', 'jid': 'xxxxxxxxxxxxxxxxxxxxxx', 'elapsed': '0.123' } }
+        let(:message) { 'fail' }
         let(:status) { 'fail' }
         let(:run_time) { 0.123 }
 


### PR DESCRIPTION
## 概要
- Sidekiq6 に対応したv2.0.0 の実装を行いました

## 変更点
- `Sidekiq::LogJsonFormatter` は `Sidekiq::Logger::Formatters::Base` を継承するようにしました
  - ref: https://github.com/mperham/sidekiq/blob/6b862a1411081619b104b9436bc647e3b24825fe/lib/sidekiq/logger.rb
- 依存先のgem をSidekiq6 に変更
- バージョン番号をv2.0.0 にアップデート
